### PR TITLE
Auto-fill task start time

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -26,9 +26,11 @@ function App() {
 
   // タスク追加
   const addTask = () => {
+    const last = tasks[tasks.length - 1];
+    const start = last ? last.end : "";
     const newTasks = [
       ...tasks,
-      { id: Math.random().toString(36).slice(2), start: "", name: "", end: "" }
+      { id: Math.random().toString(36).slice(2), start, name: "", end: "" }
     ];
     setTasks(newTasks);
     localStorage.setItem('daily-report-tasks', JSON.stringify(newTasks));


### PR DESCRIPTION
## Summary
- improve UX when adding tasks
- set the start time of a new task to the end time of the previous task

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841771f1eec8333b3dc022cb051c8a9