### PR TITLE
Refactor: migrate styles to CSS modules

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -1,0 +1,13 @@
+.container {
+  max-width: 600px;
+  margin: 2rem auto;
+  font-family: sans-serif;
+}
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.newDayButton {
+  margin-left: 16px;
+}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -5,6 +5,7 @@ import { generateReport } from "./report";
 import Button from "./components/Button";
 import TaskList from "./components/TaskList";
 import ResultArea from "./components/ResultArea";
+import styles from "./App.module.css";
 
 function App() {
   const [tasks, setTasks] = useState<Task[]>(() => {
@@ -79,11 +80,11 @@ function App() {
   };
 
   return (
-    <div style={{ maxWidth: 600, margin: '2rem auto', fontFamily: 'sans-serif' }}>
+    <div className={styles.container}>
       <h1>日報記録</h1>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      <div className={styles.header}>
         <h2>タスク一覧</h2>
-        <Button onClick={handleNewDay} style={{ marginLeft: 16 }}>
+        <Button onClick={handleNewDay} className={styles.newDayButton}>
           新規作成
         </Button>
       </div>

--- a/src/components/Button.module.css
+++ b/src/components/Button.module.css
@@ -1,0 +1,6 @@
+.button {
+  background: #eee;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 0.3em 1em;
+}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,24 +1,21 @@
 import { ReactNode } from 'react';
+import styles from './Button.module.css';
 
 type ButtonProps = {
   onClick: () => void;
   children: ReactNode;
   title?: string;
   style?: React.CSSProperties;
+  className?: string;
 };
 
-export default function Button({ onClick, children, title, style }: ButtonProps) {
+export default function Button({ onClick, children, title, style, className }: ButtonProps) {
   return (
     <button
       onClick={onClick}
       title={title}
-      style={{
-        background: '#eee',
-        border: '1px solid #ccc',
-        borderRadius: 4,
-        padding: '0.3em 1em',
-        ...style
-      }}
+      style={style}
+      className={`${styles.button} ${className ?? ''}`.trim()}
     >
       {children}
     </button>

--- a/src/components/ResultArea.module.css
+++ b/src/components/ResultArea.module.css
@@ -1,0 +1,13 @@
+.warningContainer {
+  margin: 1.5rem 0;
+}
+.warning {
+  color: red;
+  margin-left: 12px;
+}
+.resultArea {
+  background: #f4f4f4;
+  padding: 12px;
+  border-radius: 6px;
+  cursor: pointer;
+}

--- a/src/components/ResultArea.tsx
+++ b/src/components/ResultArea.tsx
@@ -1,4 +1,6 @@
 
+import styles from './ResultArea.module.css';
+
 type Props = {
   result: string;
   copyResult: () => void;
@@ -9,14 +11,14 @@ type Props = {
 export default function ResultArea({ result, copyResult, isMultiDay, hasIncomplete }: Props) {
   return (
     <>
-      <div style={{ margin: '1.5rem 0' }}>
+      <div className={styles.warningContainer}>
         {isMultiDay && (
-          <span style={{ color: 'red', marginLeft: 12 }}>
+          <span className={styles.warning}>
             日付をまたぐタスクが含まれています
           </span>
         )}
         {hasIncomplete && (
-          <span style={{ color: 'red', marginLeft: 12 }}>
+          <span className={styles.warning}>
             未入力の項目があります
           </span>
         )}
@@ -25,7 +27,7 @@ export default function ResultArea({ result, copyResult, isMultiDay, hasIncomple
         <h2>結果表示エリア</h2>
         <pre
           onClick={copyResult}
-          style={{ background: '#f4f4f4', padding: 12, borderRadius: 6, cursor: 'pointer' }}
+          className={styles.resultArea}
         >
           {result}
         </pre>

--- a/src/components/TaskList.module.css
+++ b/src/components/TaskList.module.css
@@ -1,0 +1,3 @@
+.addButton {
+  margin-top: 8px;
+}

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -1,6 +1,7 @@
 import { Task } from '../types';
 import Button from './Button';
 import TaskRow from './TaskRow';
+import styles from './TaskList.module.css';
 
 type Props = {
   tasks: Task[];
@@ -15,7 +16,7 @@ export default function TaskList({ tasks, addTask, updateTask, removeTask }: Pro
       {tasks.map(t => (
         <TaskRow key={t.id} task={t} onChange={updateTask} onRemove={removeTask} />
       ))}
-      <Button onClick={addTask} style={{ marginTop: 8 }}>
+      <Button onClick={addTask} className={styles.addButton}>
         ＋タスク追加
       </Button>
     </div>

--- a/src/components/TaskRow.module.css
+++ b/src/components/TaskRow.module.css
@@ -1,0 +1,15 @@
+.row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 4px;
+}
+.timeInput {
+  width: 80px;
+}
+.nameInput {
+  width: 120px;
+}
+.removeButton {
+  padding: 0 0.5em;
+}

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -1,5 +1,6 @@
 import Button from './Button';
 import { Task } from '../types';
+import styles from './TaskRow.module.css';
 
 type Props = {
   task: Task;
@@ -9,27 +10,27 @@ type Props = {
 
 export default function TaskRow({ task, onChange, onRemove }: Props) {
   return (
-    <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 4 }}>
+    <div className={styles.row}>
       <input
         type="time"
         value={task.start}
         onChange={e => onChange(task.id, 'start', e.target.value)}
-        style={{ width: 80 }}
+        className={styles.timeInput}
       />
       <input
         type="text"
         value={task.name}
         placeholder="タスク名"
         onChange={e => onChange(task.id, 'name', e.target.value)}
-        style={{ width: 120 }}
+        className={styles.nameInput}
       />
       <input
         type="time"
         value={task.end}
         onChange={e => onChange(task.id, 'end', e.target.value)}
-        style={{ width: 80 }}
+        className={styles.timeInput}
       />
-      <Button onClick={() => onRemove(task.id)} title="削除" style={{ padding: '0 0.5em' }}>
+      <Button onClick={() => onRemove(task.id)} title="削除" className={styles.removeButton}>
         🗑️
       </Button>
     </div>

--- a/src/cssModule.d.ts
+++ b/src/cssModule.d.ts
@@ -1,0 +1,4 @@
+declare module '*.module.css' {
+  const classes: { [key: string]: string };
+  export default classes;
+}

--- a/src/report.ts
+++ b/src/report.ts
@@ -36,7 +36,7 @@ export function generateReport(tasks: Task[]): string {
   txt += `稼働: ${formatMinutes(totalMinutes)}\n`;
   txt += `タスク一覧\n`;
   Object.entries(workMap).forEach(([name, min]) => {
-    txt += `  - ${name}　｜　${formatMinutes(min)}\n`;
+    txt += `  - ${name} | ${formatMinutes(min)}\n`;
   });
 
   return txt;

--- a/webpack.renderer.config.ts
+++ b/webpack.renderer.config.ts
@@ -4,7 +4,15 @@ import { rules } from './webpack.rules';
 import { plugins } from './webpack.plugins';
 
 rules.push({
+  test: /\.module\.css$/,
+  use: [
+    { loader: 'style-loader' },
+    { loader: 'css-loader', options: { modules: true } },
+  ],
+});
+rules.push({
   test: /\.css$/,
+  exclude: /\.module\.css$/,
   use: [{ loader: 'style-loader' }, { loader: 'css-loader' }],
 });
 


### PR DESCRIPTION
## Summary
- migrate inline styles into CSS Modules
- update components to use `className`
- add CSS module typings and config
- fix lint issue in `report.ts`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842f02097588333abbac087f6ec0da9